### PR TITLE
Fix: Publish docs on master (was main)

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -44,7 +44,7 @@ jobs:
           lake -R -Kenv=dev build PhiCalculus:docs
 
       - name: '🚀 Publish Documentation'
-        if: ${{ github.ref_name == 'main' && github.event_name == 'push' }}
+        if: ${{ github.ref_name == 'master' && github.event_name != 'pull_request' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Previously workflow was set up for `main`, but we have `master` as the main branch.
Also, allow publish docs on manual triggers.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the condition for publishing documentation. 

### Detailed summary
- Changed the condition for publishing documentation from `github.ref_name == 'main' && github.event_name == 'push'` to `github.ref_name == 'master' && github.event_name != 'pull_request'`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->