### PR TITLE
Add proofs of equivalence of closures of regular and parallel reductions

### DIFF
--- a/Minimal/Calculus.lean
+++ b/Minimal/Calculus.lean
@@ -520,19 +520,28 @@ def congOBJClos
         (Eq.ndrec ind_hypothesis
         (congrArg obj (Insert.insertTwice l b t' t_i)))
 
-def congDotClos : { t t' : Term } → { a : Attr } → (t ⇝* t') → ((dot t a) ⇝* (dot t' a))
-  | _, _, _, RedMany.nil => RedMany.nil
-  | _, _, a, @RedMany.cons l m n lm mn_many =>
+def congDotClos
+  { t t' : Term }
+  { a : Attr }
+  : (t ⇝* t') → ((dot t a) ⇝* (dot t' a))
+  | RedMany.nil => RedMany.nil
+  | @RedMany.cons l m n lm mn_many =>
     RedMany.cons (congDOT l m a lm) (congDotClos mn_many)
 
-def congAPPₗClos : { t t' u : Term } → { a : Attr } → (t ⇝* t') → ((app t a u) ⇝* (app t' a u))
-  | _, _, _, _, RedMany.nil => RedMany.nil
-  | _, _, u, a, @RedMany.cons l m n lm mn_many =>
+def congAPPₗClos
+  { t t' u : Term }
+  { a : Attr }
+  : (t ⇝* t') → ((app t a u) ⇝* (app t' a u))
+  | RedMany.nil => RedMany.nil
+  | @RedMany.cons l m n lm mn_many =>
     RedMany.cons (congAPPₗ l m u a lm) (congAPPₗClos mn_many)
 
-def congAPPᵣClos : { t u u' : Term } → { a : Attr } → (u ⇝* u') → ((app t a u) ⇝* (app t a u'))
-  | _, _, _, _, RedMany.nil => RedMany.nil
-  | t, _, _, a, @RedMany.cons l m n lm mn_many =>
+def congAPPᵣClos
+  { t u u' : Term }
+  { a : Attr }
+  : (u ⇝* u') → ((app t a u) ⇝* (app t a u'))
+  | RedMany.nil => RedMany.nil
+  | @RedMany.cons l m n lm mn_many =>
     RedMany.cons (congAPPᵣ t l m a lm) (congAPPᵣClos mn_many)
 
 def par_to_redMany {t t' : Term} : (t ⇛ t') → (t ⇝* t')


### PR DESCRIPTION
- Add `parMany_to_redMany : (t ⇛* t') → (t ⇝* t')`,
- Add `redMany_to_parMany : (t ⇝* t') → (t ⇛* t')`.

This finalizes the Proposition 3.4 about equivalence of reductions from the [_Formalizing φ-calculus_ paper](https://arxiv.org/pdf/2204.07454.pdf).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring and renaming functions related to parallel reduction. 

### Detailed summary
- Renamed `clos_trans` to `red_trans` for clarity.
- Renamed `congAPPₗClos` and `congAPPᵣClos` to `congAPPₗParMany` and `congAPPᵣParMany` respectively.
- Added new functions `parMany_to_redMany` and `redMany_to_parMany` to convert between parallel and regular reduction.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->