### PR TITLE
Confluence of parallel reduce

### DIFF
--- a/Minimal/Calculus.lean
+++ b/Minimal/Calculus.lean
@@ -1756,3 +1756,39 @@ def half_diamond
               simp [lookup_void]
               -- need to turn x ⇛ y into incLocators x ⇛ incLocators y
               exact pcongOBJ _ _ (singlePremiseInsert sorry premise)
+
+inductive BothPReduce : Term → Term → Term → Type where
+  | reduce : { u v w : Term } → (u ⇛ w) → (v ⇛ w) → BothPReduce u v w
+
+inductive BothPReduceClosure : Term → Term → Term → Type where
+  | reduce : { u v w : Term } → (u ⇛* w) → (v ⇛* w) → BothPReduceClosure u v w
+
+inductive BothReduceTo : Term → Term → Term → Type where
+  | reduce : { u v w : Term } → (u ⇝ w) → (v ⇝ w) → BothReduceTo u v w
+-- inductive BothReduceGeneric (f : Term → Term → Type) : Term → Term → Term → Type where
+--   | reduce : { u v w : Term } → (f : Term → Term → Type) → (f u w) → (f v w) → BothReduceClosure f u v w
+
+def diamond_preduce
+  { t u v : Term }
+  : (t ⇛ u)
+  → (t ⇛ v)
+  -- → ∃ w : Term, (u ⇛ w, v ⇛ w)
+  → Σ w : Term, BothPReduce u v w
+  := λ tu tv =>
+    ⟨ complete_development t
+    , BothPReduce.reduce (half_diamond tu) (half_diamond tv)
+    ⟩
+
+def confluence_preduce
+  { t u v : Term }
+  : (t ⇛* u)
+  → (t ⇛* v)
+  → Σ w : Term, BothPReduceClosure u v w
+  := λ tu tv => match tu, tv with
+    -- | ParMany.nil, ParMany.nil => ⟨t, BothPReduceClosure.reduce ParMany.nil ParMany.nil⟩
+    | ParMany.nil, tv => ⟨v, BothPReduceClosure.reduce tv ParMany.nil⟩
+    | tu, ParMany.nil => ⟨u, BothPReduceClosure.reduce ParMany.nil tu⟩
+    | @ParMany.cons _ u' _ preduce_u tail_u, @ParMany.cons _ v' _ preduce_v tail_v =>
+      let ⟨t', BothPReduce.reduce u't' v't'⟩ := diamond_preduce preduce_u preduce_v
+      sorry
+      -- ⟨w, _⟩

--- a/Minimal/Calculus.lean
+++ b/Minimal/Calculus.lean
@@ -563,33 +563,6 @@ namespace PReduce
         | Premise.nil => by
           simp [lookup]
           contradiction
-      -- | b :: bs => match l1, l2 with
-        -- | AttrList.cons _ not_in1 _ tail1, AttrList.cons _ not_in2 _ tail2 => match premise with
-        --   | Premise.consVoid _ premise_tail => by
-        --     simp [lookup]
-        --     exact dite
-        --       (b = a)
-        --       (λ eq => by
-        --         simp [lookup, eq] at lookup_attached
-        --       )
-        --       (λ neq => by
-        --         simp [lookup, neq]
-        --         simp [lookup, neq] at lookup_attached
-        --         exact lookup_attached_premise (lookup_attached) premise_tail
-        --       )
-        --   | Premise.consAttached _ _ t2 preduce premise_tail => by
-        --     simp [lookup]
-        --     exact dite
-        --       (b = a)
-        --       (λ eq => by
-        --         simp [eq]
-        --         exact ⟨t2, Pair.pair rfl preduce⟩
-        --       )
-        --       (λ neq => by
-        --         simp [neq]
-        --         simp [lookup, neq] at lookup_attached
-        --         exact lookup_attached_premise (lookup_attached) premise_tail
-        --       )
       | b :: bs => match premise with
         | Premise.consVoid _ premise_tail => by
           simp [lookup]

--- a/Minimal/Calculus.lean
+++ b/Minimal/Calculus.lean
@@ -1830,7 +1830,7 @@ inductive BothPReduceClosure : Term → Term → Term → Type where
   | reduce : { u v w : Term } → (u ⇛* w) → (v ⇛* w) → BothPReduceClosure u v w
 
 inductive BothReduceTo : Term → Term → Term → Type where
-  | reduce : { u v w : Term } → (u ⇝ w) → (v ⇝ w) → BothReduceTo u v w
+  | reduce : { u v w : Term } → (u ⇝* w) → (v ⇝* w) → BothReduceTo u v w
 
 def diamond_preduce
   { t u v : Term }
@@ -1880,3 +1880,16 @@ def confluence_preduce
       let ⟨_vv, PReduceClosureStep.step u'vv v_to_vv⟩ := confluence_step tu' tv' tail_v
       let ⟨w, BothPReduceClosure.reduce uw vvw⟩ := confluence_preduce tail_u u'vv
       ⟨w, BothPReduceClosure.reduce uw (ParMany.cons v_to_vv vvw)⟩
+
+def confluence
+  { t u v : Term }
+  : (t ⇝* u)
+  → (t ⇝* v)
+  → Σ w : Term, BothReduceTo u v w
+  := λ tu tv =>
+    let tu' := redMany_to_parMany tu
+    let tv' := redMany_to_parMany tv
+    let ⟨w, BothPReduceClosure.reduce uw' vw'⟩ := confluence_preduce tu' tv'
+    let uw := parMany_to_redMany uw'
+    let vw := parMany_to_redMany vw'
+    ⟨w, BothReduceTo.reduce uw vw⟩

--- a/Minimal/Calculus.lean
+++ b/Minimal/Calculus.lean
@@ -1420,3 +1420,23 @@ def substitution_lemma
         (by rw [eq, substitute])
         (MapAttrList.mapAttrList_lookup_void (substitute (i + 1, incLocators u')) lookup_eq)
 decreasing_by sorry
+
+
+----------------------------------------------
+-- Complete Development
+
+def complete_development : Term → Term
+  | loc n => loc n
+  | dot t a => match (complete_development t) with
+    | @obj attrs bnds => match (lookup bnds a) with
+      | some (attached t_a) => (substitute (0, (obj bnds)) t_a)
+      | some void => if ("φ" ∈ attrs) then dot (dot (obj bnds) "φ") a else dot (obj bnds) a
+      | none => dot (obj bnds) a
+    | t' => dot t' a
+  | app t a u => match (complete_development t) with
+    | @obj attrs bnds => match (lookup bnds a) with
+      | some void => obj (insert bnds a (attached (incLocators u)))
+      | _ => app (obj bnds) a (complete_development u)
+    | _ => app (complete_development t) a (complete_development u)
+  | obj bnds => obj (mapAttrList complete_development bnds)
+decreasing_by sorry


### PR DESCRIPTION
## PR overview
This PR proves confluence phi-calculus reduction.

### Detailed summary
- Added `diamond_preduce`, proving local confluence of parallel reduction.
- - Added `complete_development`, `term_to_development` and `half_diamond`  definitions required for `diamond_preduce`.
- Added `confluence_preduce`, proving confluence of parallel reduction.
- Added `confluence`, proving confluence of regular reduction.
- Added proofs of various properties of object lookups and insertions.