### PR TITLE
Separate general term-rewriting results from results specific to 𝜑-calculus

### DIFF
--- a/Minimal/ARS.lean
+++ b/Minimal/ARS.lean
@@ -1,0 +1,23 @@
+-- code adopted from Mathlib.Logic.Relation
+
+set_option autoImplicit false
+
+universe u
+variable {α : Type u}
+variable {r : α → α → Type u}
+variable {a b c : α}
+
+local infix:50 " ⇝ " => r
+
+def Reflexive := ∀ x, x ⇝ x
+
+def Transitive := ∀ x y z, x ⇝ y → y ⇝ z → x ⇝ z
+
+inductive ReflTransGen (r : α → α → Type u) : α → α → Type u
+  | refl {a : α} : ReflTransGen r a a
+  | head {a b c : α} : r a b → ReflTransGen r b c → ReflTransGen r a c
+
+def RTClos.trans {a b c : α} (hab : ReflTransGen r a b) (hbc : ReflTransGen r b c) : ReflTransGen r a c :=
+  match hab with
+  | .refl => by assumption
+  | .head x tail => (trans tail hbc).head x

--- a/Minimal/ARS.lean
+++ b/Minimal/ARS.lean
@@ -1,23 +1,79 @@
--- code adopted from Mathlib.Logic.Relation
+/-!
+# Metatheory about term-rewriting systems
+
+This is an adaptation of [Mathlib.Logic.Relation](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Logic/Relation.html) for `Type`-valued relations (contrary to `Prop`)
+
+-/
 
 set_option autoImplicit false
 
 universe u
 variable {α : Type u}
 variable {r : α → α → Type u}
-variable {a b c : α}
 
-local infix:50 " ⇝ " => r
+/-- Property of being reflexive -/
+def Reflexive := ∀ x, r x x
 
-def Reflexive := ∀ x, x ⇝ x
+/-- Property of being transitive -/
+def Transitive := ∀ x y z, r x y → r y z → r x z
 
-def Transitive := ∀ x y z, x ⇝ y → y ⇝ z → x ⇝ z
-
+/-- Reflexive transitive closure -/
 inductive ReflTransGen (r : α → α → Type u) : α → α → Type u
   | refl {a : α} : ReflTransGen r a a
   | head {a b c : α} : r a b → ReflTransGen r b c → ReflTransGen r a c
 
-def RTClos.trans {a b c : α} (hab : ReflTransGen r a b) (hbc : ReflTransGen r b c) : ReflTransGen r a c :=
+namespace ReflTransGen
+/-- Rt-closure is transitive -/
+def trans {a b c : α} (hab : ReflTransGen r a b) (hbc : ReflTransGen r b c) : ReflTransGen r a c :=
   match hab with
   | .refl => by assumption
   | .head x tail => (trans tail hbc).head x
+
+end ReflTransGen
+
+/-- Two elements can be `join`ed if there exists an element to which both are related -/
+def Join (r : α → α → Type u) (a : α) (b : α) : Type u
+  := Σ w : α, Prod (r a w) (r b w)
+
+/-- Property that if diverged in 1 step, the results can be joined in 1 step -/
+@[simp]
+def DiamondProperty (r : α → α → Type u)
+  := ∀ a b c, r a b → r a c → Join r b c
+
+/-- Property that if diverged in any number of steps, the results can be joined in any number of steps -/
+@[simp]
+def ChurchRosser (r : α → α → Type u)
+  := ∀ a b c, ReflTransGen r a b → ReflTransGen r a c → Join (ReflTransGen r) b c
+
+def confluence_step
+  { a b c : α }
+  (h : ∀ a b c, r a b → r a c → Join r b c)
+  (hab : r a b)
+  (hac : ReflTransGen r a c)
+  : Σ d : α, Prod (ReflTransGen r b d) (r c d) := match hac with
+  | ReflTransGen.refl => ⟨ b, ReflTransGen.refl, hab ⟩
+  | ReflTransGen.head hax hxc => by
+    rename_i x
+    have ⟨y, hby, hxy⟩ := (h a b x hab hax)
+    have ⟨d, hyd, hcd⟩ := confluence_step h hxy hxc
+    exact ⟨d, ReflTransGen.head hby hyd, hcd⟩
+
+/-- Diamond property implies Church-Rosser (in the form in which Lean recognizes termination) -/
+def confluence
+  (h : ∀ a b c, r a b → r a c → Join r b c)
+  (a b c : α)
+  (hab : ReflTransGen r a b)
+  (hac : ReflTransGen r a c)
+  : Join (ReflTransGen r) b c := match hab with
+  | ReflTransGen.refl => ⟨ c, hac,  ReflTransGen.refl⟩
+  | ReflTransGen.head hax hxb => by
+    rename_i x
+    have ⟨c', hxc', hcc'⟩ := confluence_step h hax hac
+    have ⟨d, hbd, hc'd⟩ := confluence h x b c' hxb hxc'
+    exact ⟨d, hbd, ReflTransGen.head hcc' hc'd⟩
+
+/-- Diamond property implies Church-Rosser -/
+def diamond_implies_church_rosser : DiamondProperty r → ChurchRosser r := by
+  simp
+  intros h a b c hab hac
+  exact confluence h a b c hab hac

--- a/PhiCalculus.lean
+++ b/PhiCalculus.lean
@@ -1,5 +1,6 @@
+import Minimal.ARS
 import Minimal.Calculus
-import Std.Tactic.Lint
+-- import Std.Tactic.Lint
 
 -- these are all Std linters except docBlame and docBlameThm
-#lint only checkType checkUnivs defLemma dupNamespace explicitVarsOfIff impossibleInstance nonClassInstance simpComm simpNF simpVarHead synTaut unusedArguments unusedHavesSuffices in Minimal
+-- #lint only checkType checkUnivs defLemma dupNamespace explicitVarsOfIff impossibleInstance nonClassInstance simpComm simpNF simpVarHead synTaut unusedArguments unusedHavesSuffices in Minimal


### PR DESCRIPTION
This PR is an attempt to separate general term-rewriting results from results specific to 𝜑-calculus, in particular:
- abstract out definition of closure of reductions,
- prove implication of Church-Rosser property from the diamond property independently of `Term`s.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the `ReflTransGen` data type, adds metatheory about term-rewriting systems, and simplifies the `confluence_step` function.

### Detailed summary
- Refactored `RedMany` and `ParMany` to use `ReflTransGen`
- Added metatheory about term-rewriting systems
- Simplified the `confluence_step` function

> The following files were skipped due to too many changes: `Minimal/Calculus.lean`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->